### PR TITLE
[Feature] Support core functions: locale + utfOffset

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rimraf -rf lib",
-    "test": "jest",
-    "coverage": "jest && codecov",
+    "test": "jest -w 1",
+    "coverage": "jest -w 1 && codecov",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,10 @@ export interface Moment {
   add(delta: number, unit: Unit): Moment;
   minus(delta: number, unit: Unit): Moment;
   subtract(delta: number, unit: Unit): Moment;
-  locale(): Moment;
 
   // value
+  locale(): string;
+  utcOffset(): number;
 
   // of
   format(pattern: string): string;
@@ -297,7 +298,11 @@ export class Moment {
   }
 
   public locale() {
-    return this;
+    return 'en'; // @TODO
+  }
+
+  public utcOffset() {
+    return -Math.round(this.$d.getTimezoneOffset() / 15) * 15;
   }
 
   public year() {

--- a/test/locale.spec.ts
+++ b/test/locale.spec.ts
@@ -1,12 +1,13 @@
 import moment from '../src';
+import * as momentjs from 'moment';
 
 // @TODO
 describe('locale', () => {
-  it('works', () => {
-    const a = moment();
-    const b = a.locale();
+  it('default en', () => {
+    // const a = moment();
+    // const b = a.locale();
 
-    expect(a).toBe(b);
-    expect(a.valueOf()).toBe(b.valueOf());
+    // expect(a).toBe(b);
+    expect(moment().locale()).toBe(momentjs().locale());
   });
 });

--- a/test/utfOffset.spec.ts
+++ b/test/utfOffset.spec.ts
@@ -1,0 +1,9 @@
+import moment from '../src';
+import * as momentjs from 'moment';
+
+// @TODO
+describe('locale', () => {
+  it('works', () => {
+    expect(moment().utcOffset()).toBe(momentjs().utcOffset());
+  });
+});


### PR DESCRIPTION
:sparkles:(core): support core functions: locale (@TODO, now default: en), utfOffset, the same as moment library functions, which fix issue from antd.DatePicker.RangePicker.getTodayTime utils caused